### PR TITLE
Feature/single fabric vnic tmpl

### DIFF
--- a/lib/bunsen/api/ucs.rb
+++ b/lib/bunsen/api/ucs.rb
@@ -324,7 +324,7 @@ module Bunsen
       @connection.in_dn = opts
       @connection.in_class = @config_class
       start = Time.now
-      #@connection.config_mo
+      @connection.config_mo
       puts "\nSpent %.2f seconds creating %s %s." % [(Time.now - start), @config_class, opts.keys[0]]
     end
     

--- a/lib/bunsen/api/ucs.rb
+++ b/lib/bunsen/api/ucs.rb
@@ -108,13 +108,13 @@ module Bunsen
             end
             vnic_temp = build_config.dup
             if vnic_temp[:switchId]
-              vnic_temp[:name] = "%s-%s"  % [item.to_s, fabric_id.downcase]
+              vnic_temp[:name] = "%s-%s"  % [item.to_s, vnic_temp[:switchId].downcase]
               if vnic_temp[:org] =~ /\/$/
                 vnic_temp[:dn] = "%slan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
               else
                 vnic_temp[:dn] = "%s/lan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
               end
-              vnic_temp[:identPoolName] = "%s-%s" % [vnic_temp[:identPoolName], fabric_id]
+              vnic_temp[:identPoolName] = "%s-%s" % [vnic_temp[:identPoolName], vnic_temp[:switchId].split("-")[0]]
               valid_keys = [:name,:dn,:mtu,:switchId,:nwCtrlPolicyName,:identPoolName,:pinToGroupName,:policyLevel,:policyOwner,:qosPolicyName,:statsPolicyName,:target,:templType]
                                       
               dn = vnic_temp[:dn]
@@ -128,7 +128,7 @@ module Bunsen
               }
             else
               ('A'..'B').each { |fabric_id|
-                #vnic_temp = build_config.dup
+                vnic_temp = build_config.dup
                 vnic_temp[:name] = "%s-%s"  % [item.to_s, fabric_id.downcase]
                 if vnic_temp[:org] =~ /\/$/
                   vnic_temp[:dn] = "%slan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
@@ -315,7 +315,7 @@ module Bunsen
       @connection.in_dn = opts
       @connection.in_class = @config_class
       start = Time.now
-      @connection.config_mo
+      #@connection.config_mo
       puts "\nSpent %.2f seconds creating %s %s." % [(Time.now - start), @config_class, opts.keys[0]]
     end
     

--- a/lib/bunsen/api/ucs.rb
+++ b/lib/bunsen/api/ucs.rb
@@ -106,28 +106,51 @@ module Bunsen
             else
               build_config = config_copy
             end
-            ('A'..'B').each { |fabric_id|
-              vnic_temp = build_config.dup
+            vnic_temp = build_config.dup
+            if vnic_temp[:switchId]
               vnic_temp[:name] = "%s-%s"  % [item.to_s, fabric_id.downcase]
               if vnic_temp[:org] =~ /\/$/
                 vnic_temp[:dn] = "%slan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
               else
                 vnic_temp[:dn] = "%s/lan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
               end
-              vnic_temp[:switchId] = fabric_id
               vnic_temp[:identPoolName] = "%s-%s" % [vnic_temp[:identPoolName], fabric_id]
               valid_keys = [:name,:dn,:mtu,:switchId,:nwCtrlPolicyName,:identPoolName,:pinToGroupName,:policyLevel,:policyOwner,:qosPolicyName,:statsPolicyName,:target,:templType]
-              
+                                      
               dn = vnic_temp[:dn]
               new_config[dn] ||= {}
-        
+                                    
               vnic_temp.each { |key,value|
                 case key
                 when *valid_keys
                   new_config[dn][key] = value
                 end
               }
-            }
+            else
+              ('A'..'B').each { |fabric_id|
+                #vnic_temp = build_config.dup
+                vnic_temp[:name] = "%s-%s"  % [item.to_s, fabric_id.downcase]
+                if vnic_temp[:org] =~ /\/$/
+                  vnic_temp[:dn] = "%slan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
+                else
+                  vnic_temp[:dn] = "%s/lan-conn-templ-%s" % [vnic_temp[:org], vnic_temp[:name]]
+                end
+                vnic_temp[:switchId] = fabric_id
+                vnic_temp[:identPoolName] = "%s-%s" % [vnic_temp[:identPoolName], fabric_id]
+                valid_keys = [:name,:dn,:mtu,:switchId,:nwCtrlPolicyName,:identPoolName,:pinToGroupName,:policyLevel,:policyOwner,:qosPolicyName,:statsPolicyName,:target,:templType]
+                          
+                dn = vnic_temp[:dn]
+                new_config[dn] ||= {}
+                      
+                vnic_temp.each { |key,value|
+                  case key
+                  when *valid_keys
+                    new_config[dn][key] = value
+                  end
+                }
+              }
+            end
+            
             
             
           end


### PR DESCRIPTION
This PR adds the following features:

Support for passing :switchId with vnic_templates to manually specify combinations of vnic template fabric configurations. Default behavior is to automatically create an A and B vnic template with no failover set. This feature allows this to be done manually or to provide the ability to pin a vnic_template to a specific fabric with (A-B or B-A) or without (A or B) failover. 

Changed vlan to vnic template association to reference the :switchId configuration on the vnic_template. If using the default of no :switchId provided the vlan will be associated to both the A and B vnic templates that get created. If :switchId is provided the field gets used to identify the proper vnic_template to associate the vlan to.
